### PR TITLE
Fixed a bug which prevents the TimingBudget from being set correctly

### DIFF
--- a/library/public/src/VL53L1X_api.c
+++ b/library/public/src/VL53L1X_api.c
@@ -341,7 +341,7 @@ VL53L1X_Status_t VL53L1X_SetTimingBudgetInMs(uint16_t dev, uint16_t timingBudget
     }
   }
 
-  status |= VL53L1X_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI, rangeA);
+  status |= VL53L1X_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI, rangeA);
   status |= VL53L1X_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI, rangeB);
   return status;
 }


### PR DESCRIPTION
The rangeA and rangeB values for the timing budget were written to the same register on the device. This prevented the timing budget to be set.